### PR TITLE
feat: allow CORS for frontend origin https://wom-auth-service-client.…

### DIFF
--- a/src/main/java/com/wom/auth/config/SecurityConfig.java
+++ b/src/main/java/com/wom/auth/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:4200"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:4200", "https://wom-auth-service-client.fly.dev"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
### Título del PR:
**feat: Permitir CORS para el origen del frontend en producción**

### Descripción del PR:
Esta PR soluciona el error de CORS que ocurre cuando el frontend desplegado en Fly.io (https://wom-auth-service-client.fly.dev) intenta acceder a la API del backend. Se actualiza la configuración de CORS en `SecurityConfig.java` para permitir el origen del frontend en producción, manteniendo también el origen local para desarrollo.

Cambios principales:
- Agregar `https://wom-auth-service-client.fly.dev` a la lista de orígenes permitidos en CORS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved CORS errors for users accessing the service from the hosted client domain, enabling successful sign-in and API interactions without cross-origin blocks.

* **Chores**
  * Expanded allowed origins in CORS settings to include the deployed client domain alongside the local development address. No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->